### PR TITLE
Improvements to reader and libfuzzer interfacing

### DIFF
--- a/input/reader_test.go
+++ b/input/reader_test.go
@@ -169,3 +169,44 @@ func TestDynamicArgsZeroWeight(t *testing.T) {
 		t.Fatalf("result wrong\nhave %q\nwant %q", have, want)
 	}
 }
+
+func TestExhausted(t *testing.T) {
+	input := NewSource(make([]byte, 8))
+	input.fillArg(reflect.TypeOf(uint64(0)), 0)          // Consumes 8 byte
+	input.fillArg(reflect.TypeOf([]byte{}), input.Len()) // Consumes nothing
+	input.fillArg(reflect.TypeOf(""), input.Len())       // Consumes nothing
+	if input.IsExhausted() {
+		t.Fatalf("expected not exhausted")
+	}
+	input.fillArg(reflect.TypeOf(uint8(0)), 0) // Consumes 1 byte
+	if !input.IsExhausted() {
+		t.Fatalf("expected exhausted")
+	}
+}
+
+func TestReader(t *testing.T) {
+
+	{
+		s := NewSource(fibonacci(100))
+		s.Bytes(100)
+		if s.IsExhausted() {
+			t.Fatal("exp not exhausted")
+		}
+	}
+	{
+		s := NewSource(fibonacci(100))
+		s.Bytes(101)
+		if !s.IsExhausted() {
+			t.Fatal("exp exhausted")
+		}
+	}
+	{
+		s := NewSource(fibonacci(100))
+		s.Bytes(100)
+		s.Bytes(0)
+		s.Bytes(0)
+		if s.IsExhausted() {
+			t.Fatal("exp not exhausted")
+		}
+	}
+}

--- a/template.txt
+++ b/template.txt
@@ -27,7 +27,7 @@ func LibFuzzer{{.Func}}(data []byte) int {
 	fuzzer := testing.NewF(data)
 	defer fuzzer.Finished()
 	target.{{.Func}}(fuzzer)
-	return 1
+	return fuzzer.ReturnValue()
 }
 
 func catchPanics() {

--- a/testdata/main.output.want
+++ b/testdata/main.output.want
@@ -27,7 +27,7 @@ func LibFuzzerFuzzEncoder(data []byte) int {
 	fuzzer := testing.NewF(data)
 	defer fuzzer.Finished()
 	target.FuzzEncoder(fuzzer)
-	return 1
+	return fuzzer.ReturnValue()
 }
 
 func catchPanics() {

--- a/testing/f.go
+++ b/testing/f.go
@@ -8,11 +8,11 @@ import (
 
 type F struct {
 	common
-	data []byte
+	s *input.Source
 }
 
 func NewF(data []byte) *F {
-	return &F{data: data}
+	return &F{s: input.NewSource(data)}
 }
 
 // Add will add the arguments to the seed corpus for the fuzz test. This will be
@@ -22,5 +22,30 @@ func NewF(data []byte) *F {
 func (f *F) Add(args ...any) {}
 
 func (f *F) Fuzz(ff any) {
-	input.NewSource(f.data).FillAndCall(ff, reflect.ValueOf(new(T)))
+	f.s.FillAndCall(ff, reflect.ValueOf(new(T)))
+}
+
+// ReturnValue returns a value for libfuzzer. Docs:
+//
+// > By default, the fuzzing engine will generate input of any arbitrary length.
+// > This might be useful to try corner cases that could lead to a security
+// > vulnerability. However, if large inputs are not necessary to increase the
+// > coverage of your target API, it is important to add a limit here to
+// > significantly improve performance.
+// >
+// > 	if (size < kMinInputLength || size > kMaxInputLength)
+// > 		return 0;
+//
+// By default: return 1
+// We do this by checking how much data the fuzzer tried to consume.
+func (f *F) ReturnValue() int {
+	if f.s.IsExhausted() {
+		return 0
+	}
+	// We're a bit lenient, but if the input is >2x the used portion, then return
+	// 0 to limit it. (== used amount < remaining amount)
+	if f.s.Used() < f.s.Len() {
+		return 0
+	}
+	return 1
 }


### PR DESCRIPTION
This change makes the reader use direct slice access, and makes `f` signal a returnvalue to libfuzzer, if input is too small or too large.